### PR TITLE
Automate Pi setup; fix ramp, busy-loop, and USB-connect logic

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+*.py text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Node-Red's atomic-write backup files (regenerated on every Deploy)
+RPi/node-red/.flows.json.backup
+RPi/node-red/.flows_cred.json.backup
+
+# Local Claude Code per-user settings
+.claude/

--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ The Arduino installation is just uploading the latest version in the [Arduino fo
 ## Raspberry Pi Installation
 For the raspberry pi to run correctly, we need to install a few things.
 
+### Quick start: `install.sh`
+After cloning the repo on the Pi, run the install script as the `pi` user:
+
+```bash
+cd ~/Documents/Spit-electronics
+./RPi/install.sh
+```
+
+It installs Mosquitto and the Python deps, points Node-Red at the repo flow file, and adds the `start_spit.sh` boot entry to crontab. It's idempotent — safe to re-run after a `git pull`.
+
+**Prerequisite**: Node-Red must already be installed. If it isn't, run the [official installer](https://nodered.org/docs/getting-started/raspberrypi#installing-and-upgrading-node-red), then re-run `install.sh`.
+
+The rest of this section documents what the script does, in case you want to do it by hand or debug a step.
+
 ### Installing Mosquitto broker
 Run the following command to upgrade and update your system:
 
@@ -119,7 +133,9 @@ where `pathToRepo` is the absolute path to this repository. Then restart Node-Re
 
 `sudo systemctl restart nodered.service`
 
-Every Deploy in the browser now writes straight into the repo file, so `git diff` shows your flow changes. The rest of the Node-Red state (`settings.js`, installed palette nodes, sessions) stays in `~/.node-red/` and out of the repo.
+Every Deploy in the browser now writes straight into the repo file, so `git diff` shows your flow changes. The rest of the Node-Red state (`settings.js`, installed palette nodes, sessions) stays in `~/.node-red/` and out of the repo. Edit `settings.js` over SSH (e.g. with `nano`), not via SFTP — uploading from a local mirror is a known way to silently revert the `flowFile` line.
+
+Node-Red also writes `.flows.json.backup` and `.flows_cred.json.backup` next to the flow file on every Deploy (its one-step undo). Both are `.gitignore`d.
 
 Note: `flows_cred.json` is encrypted, but the key lives in `settings.js`. Only commit `flows_cred.json` if you're certain none of your flow credentials are sensitive.
 
@@ -172,7 +188,6 @@ so if want to kill the Spit program, I would do
 `kill 2102`. You can then run the `grep` command again to check if it is indeed killed.
 
 ## TODO
-- point node-red to correct flow.json. Settings file seems to get overwritten? Maybe edit via terminal instead of SFTP Bitvise
 - Add data logging and replay
 - Add visualization
 - Add sound with speakers

--- a/README.md
+++ b/README.md
@@ -9,6 +9,43 @@ The RPi uses MQTT to make the data that is received in the Python script availab
 
 !!!!!!TODO: add picture!!!!!
 
+## How the Pi and Arduino communicate
+Both sides use the SerialTransfer protocol over `/dev/ttyACM0` at 115200 baud — a framed, CRC-checked packet format where you stuff a binary buffer with `txObj`/`tx_obj` and read it back with `rxObj`/`rx_obj` in the same field order. No JSON, no text — the byte layout must match exactly, in the same order, on both sides.
+
+### Pi → Arduino (commands)
+The Pi re-sends the *whole* packet on every incoming MQTT message (`sendData()` in the Python script). So if you only tweak the I-gain in Node-Red, the Arduino still gets the unchanged P, feed-forward, and start/stop values too.
+
+| Offset | Field          | Type   | Pi source                | Arduino sink         |
+|--------|----------------|--------|--------------------------|----------------------|
+| 0      | `vel_ref`      | float  | Node-Red slider          | `vel_ref_receive`    |
+| 4      | `P_gain`       | float  | Node-Red (clamped 0–5)   | `P`                  |
+| 8      | `I_action`     | float  | Node-Red (clamped 0–15)  | `I_action`           |
+| 12     | `feed_forward` | float  | Node-Red                 | `feed_forward`       |
+| 16     | `start_stop`   | uint8  | Node-Red bool `"true"`   | `start_stop_RPi`     |
+
+### Arduino → Pi (telemetry)
+Every 50 ms the Arduino sends:
+
+| Offset | Field         | Type   | Meaning                                  |
+|--------|---------------|--------|------------------------------------------|
+| 0      | `control_vel` | float  | Moving-average measured velocity         |
+| 4      | `encoderSend` | uint32 | Raw encoder pulse count since boot       |
+
+The Pi divides the encoder count by 305 to get `num_rounds` and republishes both on MQTT (`mqtt/rpi/vel_measured`, `mqtt/rpi/num_rounds`) for Node-Red to graph.
+
+### Control flow on the Arduino
+1. **Two input sources** — a physical pot on `A0` and the Pi over serial. A latching flag `started_from_RPi` decides which `vel_ref` wins. The Pi only "owns" the motor if the start command came from the Pi; pressing the local start button reverts to the pot.
+2. **Start/stop edge detection** — `start_stop_RPi` is treated as level, but only acts on the rising/falling edge (`start_stop_RPi && !start_stop_RPi_prev`). Repeated `"true"` payloads from Node-Red don't re-trigger.
+3. **PI + feed-forward controller** — `ctrl = P*error + I_action*∫error + feed_forward`, integral anti-windup clamped to ±10, output saturated to 0–100 % duty, written via Timer4 fast PWM on pin D6 at ~23 kHz.
+4. **Velocity sensing** — an ISR on pin 7 increments `encoderValue` and computes the instantaneous `vel = 1/dt`; this is smoothed by `velMovingAvg` and divided by 3 before being fed to the controller as `control_vel`.
+
+### Things to be aware of
+- **Field order is load-bearing.** If you add a new gain on the Pi side, you must add the matching `rxObj` on the Arduino in the same position, or every following field shifts and gets garbage.
+- **`delay(1 / 500)` in the Arduino main loop is `delay(0)`** — integer division. The loop runs as fast as it can, not at 500 Hz.
+- **`config1kHzLoop` is defined but never called** — the 1 kHz timer ISR scaffolding is dead code right now. Control runs in the main loop, not on a timer interrupt.
+- **`deltaTmain` uses millisecond resolution** via `millis()`, so the integral term's step size jitters by ±1 ms per loop iteration.
+- **No integral reset when switching pot↔Pi** — only on stop and on `vel_ref < 0.1`. Quickly toggling sources mid-run will carry integral history across.
+
 ## Arduino Installation
 ### Install libraries
 Using the Arduino IDE library manager, install the following libraries:
@@ -97,7 +134,6 @@ so if want to kill the Spit program, I would do
 `kill 2102`. You can then run the `grep` command again to check if it is indeed killed.
 
 ## TODO
-- Fix I_action = float(msg.payload.decode()) -> ValueError: could not convert string to float: '' -> occurs when in NodeRed we leave the box empty of any value, 
 - Add data logging and replay
 - Add visualization
 - Add sound with speakers

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ so if want to kill the Spit program, I would do
 `kill 2102`. You can then run the `grep` command again to check if it is indeed killed.
 
 ## TODO
+- Add ramp on each (large) setpoint change
+- point node-red to correct flow.json. Settings file seems to get overwritten? Maybe edit via terminal instead of SFTP Bitvise
 - Add data logging and replay
 - Add visualization
 - Add sound with speakers

--- a/README.md
+++ b/README.md
@@ -95,3 +95,10 @@ pi          2119    1566  0 21:18 pts/0    00:00:00 grep --color=auto python
 ```
 so if want to kill the Spit program, I would do
 `kill 2102`. You can then run the `grep` command again to check if it is indeed killed.
+
+## TODO
+- Fix I_action = float(msg.payload.decode()) -> ValueError: could not convert string to float: '' -> occurs when in NodeRed we leave the box empty of any value, 
+- Add data logging and replay
+- Add visualization
+- Add sound with speakers
+- Add system identification

--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ For example on usage, see the [Python script in this repository](RPi/Spit_RPi_Ar
 ### Installing Node-Red
 It is best to follow the instructions from the [node-red source](https://nodered.org/docs/getting-started/raspberrypi#installing-and-upgrading-node-red). Be sure to make it [autostart on boot](https://nodered.org/docs/getting-started/raspberrypi#autostart-on-boot). The editor can then be accessed in a [webbrowser](https://nodered.org/docs/getting-started/raspberrypi#opening-the-editor).
 
+#### Point Node-Red at the repo flow
+By default Node-Red reads and writes its flow from `~/.node-red/flows.json`, so the [flow checked into this repo](RPi/node-red) is ignored unless you tell Node-Red to use it. Edit `~/.node-red/settings.js` and set:
+
+```js
+flowFile: 'pathToRepo/RPi/node-red/flows.json',
+credentialsFile: 'pathToRepo/RPi/node-red/flows_cred.json',
+```
+
+where `pathToRepo` is the absolute path to this repository. Then restart Node-Red:
+
+`sudo systemctl restart nodered.service`
+
+Every Deploy in the browser now writes straight into the repo file, so `git diff` shows your flow changes. The rest of the Node-Red state (`settings.js`, installed palette nodes, sessions) stays in `~/.node-red/` and out of the repo.
+
+Note: `flows_cred.json` is encrypted, but the key lives in `settings.js`. Only commit `flows_cred.json` if you're certain none of your flow credentials are sensitive.
+
 ### Autostart Python script on boot
 Use `crontab` to make the RPi run the [start script](RPi/bash_scripts/start_spit.sh) on boot. First open `crontab`:
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ Just select `nano` as the editor. Then add the `start_spit.sh` to the boot comma
 
 where `pathToRepo` is the path to this repository.
 
+## Network reference
+Current addresses for the dev setup. Update if anything is re-IP'd.
+
+| Device                              | MAC                 | IP              |
+|-------------------------------------|---------------------|-----------------|
+| Raspberry Pi (`eth0`, to dev router) | `DC:A6:32:4C:EF:69` | `192.168.2.100` |
+| Dev router (Pi ↔ laptop bridge)      | —                   | `192.168.2.10`  |
+
+The Pi's Wi-Fi interface (`wlan0`) gets a DHCP lease from the Odido router on a different subnet and is the path to the internet. Reach the Pi over Ethernet at `192.168.2.100` (e.g. `ssh pi@192.168.2.100`); reach it over Wi-Fi at whatever its current `wlan0` lease is (`ip a` on the Pi).
+
 ## Connecting the Spit
 TODO
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Use `pip` to install the paho-mqtt library:
 
 `pip install paho-mqtt`
 
-For example on usage, see the [Python script in this repository](RPi/Spit_RPi_Arduino_V3.py). For more information and explanation, see https://medium.com/@potekh.anastasia/a-beginners-guide-to-mqtt-understanding-mqtt-mosquitto-broker-and-paho-python-mqtt-client-990822274923.
+For example on usage, see the [Python script in this repository](RPi/Spit_RPi_Arduino.py). For more information and explanation, see https://medium.com/@potekh.anastasia/a-beginners-guide-to-mqtt-understanding-mqtt-mosquitto-broker-and-paho-python-mqtt-client-990822274923.
 
 ### Installing Node-Red
 It is best to follow the instructions from the [node-red source](https://nodered.org/docs/getting-started/raspberrypi#installing-and-upgrading-node-red). Be sure to make it [autostart on boot](https://nodered.org/docs/getting-started/raspberrypi#autostart-on-boot). The editor can then be accessed in a [webbrowser](https://nodered.org/docs/getting-started/raspberrypi#opening-the-editor).
@@ -183,7 +183,7 @@ where `CodeYouFound` is of course the code you found in the previous step.
 For instance, when running the `grep` command I get
 ```
 pi          1160       1  0 20:42 ?        00:00:00 /usr/bin/python3 /usr/share/system-config-printer/applet.py
-pi          2102    2085 67 21:18 pts/0    00:00:04 python3 ../Spit_RPi_Arduino_V3.py
+pi          2102    2085 67 21:18 pts/0    00:00:04 python3 ../Spit_RPi_Arduino.py
 pi          2119    1566  0 21:18 pts/0    00:00:00 grep --color=auto python
 ```
 so if want to kill the Spit program, I would do

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ cd ~/Documents/Spit-electronics
 
 It installs Mosquitto and the Python deps, points Node-Red at the repo flow file, and adds the `start_spit.sh` boot entry to crontab. It's idempotent — safe to re-run after a `git pull`.
 
+By default it does *not* run `apt upgrade`. Pass `--upgrade` if you want a full system upgrade as part of the install: `./RPi/install.sh --upgrade`.
+
 **Prerequisite**: Node-Red must already be installed. If it isn't, run the [official installer](https://nodered.org/docs/getting-started/raspberrypi#installing-and-upgrading-node-red), then re-run `install.sh`.
 
 The rest of this section documents what the script does, in case you want to do it by hand or debug a step.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Both sides use the SerialTransfer protocol over `/dev/ttyACM0` at 115200 baud �
 ### Pi → Arduino (commands)
 The Pi re-sends the *whole* packet on every incoming MQTT message (`sendData()` in the Python script). So if you only tweak the I-gain in Node-Red, the Arduino still gets the unchanged P, feed-forward, and start/stop values too.
 
+`vel_ref` is also rate-limited on the Pi side before it goes out — see [Setpoint ramping](#setpoint-ramping) below.
+
 | Offset | Field          | Type   | Pi source                | Arduino sink         |
 |--------|----------------|--------|--------------------------|----------------------|
 | 0      | `vel_ref`      | float  | Node-Red slider          | `vel_ref_receive`    |
@@ -38,6 +40,16 @@ The Pi divides the encoder count by 305 to get `num_rounds` and republishes both
 2. **Start/stop edge detection** — `start_stop_RPi` is treated as level, but only acts on the rising/falling edge (`start_stop_RPi && !start_stop_RPi_prev`). Repeated `"true"` payloads from Node-Red don't re-trigger.
 3. **PI + feed-forward controller** — `ctrl = P*error + I_action*∫error + feed_forward`, integral anti-windup clamped to ±10, output saturated to 0–100 % duty, written via Timer4 fast PWM on pin D6 at ~23 kHz.
 4. **Velocity sensing** — an ISR on pin 7 increments `encoderValue` and computes the instantaneous `vel = 1/dt`; this is smoothed by `velMovingAvg` and divided by 3 before being fed to the controller as `control_vel`.
+
+### Setpoint ramping
+To avoid jolts when the motor would otherwise see a step change, the Python script ramps `vel_ref` toward the slider value (`vel_ref_target`) at `RAMP_RATE` units/sec instead of sending the new setpoint immediately. Two triggers:
+
+- **On Start** (`start_stop` rising edge): if the gap between `vel_ref_target` and the measured velocity exceeds `RAMP_TRIGGER_GAP`, `vel_ref` is reset to 0 and ramped up from there. Small gaps step straight to the target.
+- **While running**: if a new slider value differs from the current `vel_ref` by more than `RAMP_TRIGGER_GAP`, the script ramps from the current `vel_ref` to the new target (both directions). Small changes step through immediately.
+
+If the slider moves again mid-ramp, only `vel_ref_target` updates — the in-flight ramp re-aims at the new target on the next step instead of restarting.
+
+Constants live near the top of [`Spit_RPi_Arduino.py`](RPi/Spit_RPi_Arduino.py): `RAMP_RATE` (units/sec), `RAMP_TRIGGER_GAP` (deadband, units), `RAMP_STEP_INTERVAL` (seconds between steps). The Arduino itself does no ramping — if the local pot is the source, the controller sees raw pot values.
 
 ### Things to be aware of
 - **Field order is load-bearing.** If you add a new gain on the Pi side, you must add the matching `rxObj` on the Arduino in the same position, or every following field shifts and gets garbage.
@@ -160,7 +172,6 @@ so if want to kill the Spit program, I would do
 `kill 2102`. You can then run the `grep` command again to check if it is indeed killed.
 
 ## TODO
-- Add ramp on each (large) setpoint change
 - point node-red to correct flow.json. Settings file seems to get overwritten? Maybe edit via terminal instead of SFTP Bitvise
 - Add data logging and replay
 - Add visualization

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Use `crontab` to make the RPi run the [start script](RPi/bash_scripts/start_spit
 
 Just select `nano` as the editor. Then add the `start_spit.sh` to the boot command:
 
-`@reboot pathToRepo/RPi/bash_scripts/start_spit.sh`
+`@reboot sleep 10 pathToRepo/RPi/bash_scripts/start_spit.sh >> /home/pi/crontab_log.txt 2>&1`
 
 where `pathToRepo` is the path to this repository.
 

--- a/RPi/Spit_RPi_Arduino.py
+++ b/RPi/Spit_RPi_Arduino.py
@@ -9,6 +9,7 @@ hostname = "localhost"
 broker_port = 1883
 send_measured_num_rounds = "mqtt/rpi/num_rounds"
 send_measured_vel_topic = "mqtt/rpi/vel_measured"
+send_vel_ref_topic = "mqtt/rpi/vel_ref_sent"
 receive_vel_ref_topic = "mqtt/rpi/rx/vel_ref"
 receive_startstop_topic = "mqtt/rpi/rx/start_stop"
 receive_p_gain_topic = "mqtt/rpi/rx/p_gain"
@@ -34,12 +35,25 @@ if receive_client.connect("localhost", broker_port, 60) != 0:
 
 message = str([])
 send_client.publish(send_measured_vel_topic, message)
+send_client.publish(send_vel_ref_topic, str(0.0))
 
 start_stop = 0
 vel_ref = 0.0
+vel_ref_target = 0.0
 P_gain = 2.0
 I_action = 10.0
 feed_forward = 10.0
+
+# Soft-start ramp: when the user toggles start while measured velocity is far
+# from the target, vel_ref is ramped from the current measured value up to
+# vel_ref_target at RAMP_RATE units/sec instead of stepping there immediately.
+RAMP_RATE = 10.0
+RAMP_TRIGGER_GAP = 1.0
+RAMP_STEP_INTERVAL = 0.05
+
+prev_start_stop = 0
+ramping = False
+last_ramp_time = 0.0
 
 def sendData():
     sendSize = 0
@@ -83,12 +97,61 @@ def make_float_handler(var_name, lo=None, hi=None):
         sendData()
     return handler
 
+def publish_vel_ref_sent():
+    send_client.publish(send_vel_ref_topic, str(vel_ref))
+
+def message_handling_vel_ref(client, userdata, msg):
+    global vel_ref, vel_ref_target
+    payload = msg.payload.decode().strip()
+    if payload == "":
+        return
+    vel_ref_target = float(payload)
+    if not ramping:
+        vel_ref = vel_ref_target
+        publish_vel_ref_sent()
+        sendData()
+
 def message_handling_start_stop(client, userdata, msg):
-    global start_stop
+    global start_stop, prev_start_stop, vel_ref, ramping, last_ramp_time
     start_stop = 1 if msg.payload.decode() == "true" else 0
+
+    if start_stop == 1 and prev_start_stop == 0:
+        if abs(vel_ref_target - vel_measured) > RAMP_TRIGGER_GAP:
+            vel_ref = max(vel_measured, 0.0)
+            ramping = True
+            last_ramp_time = time.time()
+        else:
+            vel_ref = vel_ref_target
+            ramping = False
+        publish_vel_ref_sent()
+    elif start_stop == 0:
+        ramping = False
+
+    prev_start_stop = start_stop
     sendData()
 
-message_handling_vel_ref      = make_float_handler("vel_ref")
+def ramp_step():
+    global vel_ref, ramping, last_ramp_time
+    if not ramping:
+        return
+    now = time.time()
+    dt = now - last_ramp_time
+    if dt < RAMP_STEP_INTERVAL:
+        return
+    last_ramp_time = now
+
+    step = RAMP_RATE * dt
+    diff = vel_ref_target - vel_ref
+    if abs(diff) <= step:
+        vel_ref = vel_ref_target
+        ramping = False
+    elif diff > 0:
+        vel_ref += step
+    else:
+        vel_ref -= step
+    sendData()
+    publish_vel_ref_sent()
+
 message_handling_P_gain       = make_float_handler("P_gain", 0.0, 5.0)
 message_handling_I_action     = make_float_handler("I_action", 0.0, 15.0)
 message_handling_feed_forward = make_float_handler("feed_forward")
@@ -135,14 +198,8 @@ if __name__ == '__main__':
             if sim_enabled == "sim":
                 print("Simulation mode")
         while True:
-            ###################################################################
-            # Transmit all the data to send in a single packet
-            ###################################################################
-            
-            # send_size = 0
-            ###################################################################
-            # Receive a float
-            ###################################################################
+            ramp_step()
+
             if link.available():
                 
                 

--- a/RPi/Spit_RPi_Arduino.py
+++ b/RPi/Spit_RPi_Arduino.py
@@ -179,7 +179,7 @@ receive_client.subscribe(receive_topic)
 
 if __name__ == '__main__':
     try:
-        while ~USB_connection_started and USB_connect_attemps <= USB_max_connect_attemps:
+        while not USB_connection_started and USB_connect_attemps <= USB_max_connect_attemps:
             try:
                 link = txfer.SerialTransfer('/dev/ttyACM0')
                 link.open()
@@ -192,7 +192,7 @@ if __name__ == '__main__':
             else:
                 break
         
-        if ~USB_connection_started and USB_connect_attemps >= 1:
+        if not USB_connection_started and USB_connect_attemps >= 1:
             print("Could not connect to Arduino via USB, stopping program.")
             exit(0)
         print("Starting MQTT receive")

--- a/RPi/Spit_RPi_Arduino.py
+++ b/RPi/Spit_RPi_Arduino.py
@@ -42,12 +42,12 @@ vel_ref = 0.0
 vel_ref_target = 0.0
 P_gain = 2.0
 I_action = 10.0
-feed_forward = 10.0
+feed_forward = 0.0
 
 # Soft-start ramp: when the user toggles start while measured velocity is far
 # from the target, vel_ref is ramped from the current measured value up to
 # vel_ref_target at RAMP_RATE units/sec instead of stepping there immediately.
-RAMP_RATE = 10.0
+RAMP_RATE = 25.0
 RAMP_TRIGGER_GAP = 1.0
 RAMP_STEP_INTERVAL = 0.05
 
@@ -117,7 +117,7 @@ def message_handling_start_stop(client, userdata, msg):
 
     if start_stop == 1 and prev_start_stop == 0:
         if abs(vel_ref_target - vel_measured) > RAMP_TRIGGER_GAP:
-            vel_ref = max(vel_measured, 0.0)
+            vel_ref = 0.0
             ramping = True
             last_ramp_time = time.time()
         else:

--- a/RPi/Spit_RPi_Arduino.py
+++ b/RPi/Spit_RPi_Arduino.py
@@ -44,9 +44,10 @@ P_gain = 2.0
 I_action = 10.0
 feed_forward = 0.0
 
-# Soft-start ramp: when the user toggles start while measured velocity is far
-# from the target, vel_ref is ramped from the current measured value up to
-# vel_ref_target at RAMP_RATE units/sec instead of stepping there immediately.
+# Ramp: on Start, vel_ref ramps from 0 up to vel_ref_target. While running,
+# a setpoint change larger than RAMP_TRIGGER_GAP ramps from the current
+# vel_ref toward the new target at RAMP_RATE units/sec; smaller changes step
+# through immediately.
 RAMP_RATE = 25.0
 RAMP_TRIGGER_GAP = 1.0
 RAMP_STEP_INTERVAL = 0.05
@@ -101,12 +102,20 @@ def publish_vel_ref_sent():
     send_client.publish(send_vel_ref_topic, str(vel_ref))
 
 def message_handling_vel_ref(client, userdata, msg):
-    global vel_ref, vel_ref_target
+    global vel_ref, vel_ref_target, ramping, last_ramp_time
     payload = msg.payload.decode().strip()
     if payload == "":
         return
     vel_ref_target = float(payload)
-    if not ramping:
+
+    if ramping:
+        # An in-progress ramp will re-aim at the new target on the next ramp_step.
+        return
+
+    if start_stop == 1 and abs(vel_ref_target - vel_ref) > RAMP_TRIGGER_GAP:
+        ramping = True
+        last_ramp_time = time.time()
+    else:
         vel_ref = vel_ref_target
         publish_vel_ref_sent()
         sendData()

--- a/RPi/Spit_RPi_Arduino.py
+++ b/RPi/Spit_RPi_Arduino.py
@@ -207,6 +207,9 @@ if __name__ == '__main__':
             if sim_enabled == "sim":
                 print("Simulation mode")
         while True:
+            # 1 kHz poll — 20x faster than the Arduino's 50 ms telemetry interval.
+            # Without this the loop pegs a CPU core busy-waiting on link.available().
+            time.sleep(0.001)
             ramp_step()
 
             if link.available():

--- a/RPi/Spit_RPi_Arduino.py
+++ b/RPi/Spit_RPi_Arduino.py
@@ -71,62 +71,27 @@ def sendData():
 
     link.send(sendSize)
 
+def make_float_handler(var_name, lo=None, hi=None):
+    def handler(client, userdata, msg):
+        payload = msg.payload.decode().strip()
+        if payload == "":
+            return
+        value = float(payload)
+        if lo is not None:
+            value = min(max(value, lo), hi)
+        globals()[var_name] = value
+        sendData()
+    return handler
+
 def message_handling_start_stop(client, userdata, msg):
-    # Define global variable to be able to modify it in function
     global start_stop
-
-    # Decode payload coming from MQTT node
-    if msg.payload.decode() == "true":
-        start_stop = 1
-    else:
-        start_stop = 0
-
-    # print("startstop: ", start_stop)
-
-    # Send all data
+    start_stop = 1 if msg.payload.decode() == "true" else 0
     sendData()
 
-def message_handling_vel_ref(client, userdata, msg):
-    # Define global variable to be able to modify it in function
-    global vel_ref
-
-    # Decode payload coming from MQTT node
-    vel_ref = float(msg.payload.decode())
-
-    # Send all data
-    sendData()
-
-def message_handling_P_gain(client, userdata, msg):
-    # Define global variable to be able to modify it in function
-    global P_gain
-
-    # Decode payload coming from MQTT node
-    P_gain = float(msg.payload.decode())
-    P_gain = min(max(P_gain, 0.0), 5.0)
-
-    # Send all data
-    sendData()
-
-def message_handling_I_action(client, userdata, msg):
-    # Define global variable to be able to modify it in function
-    global I_action
-
-    # Decode payload coming from MQTT node
-    I_action = float(msg.payload.decode())
-    I_action = min(max(I_action, 0.0), 15.0)
-
-    # Send all data
-    sendData()
-
-def message_handling_feed_forward(client, userdata, msg):
-    # Define global variable to be able to modify it in function
-    global feed_forward
-
-    # Decode payload coming from MQTT node
-    feed_forward = float(msg.payload.decode())
-    # print("feed-forward: ", feed_forward)
-    # Send all data
-    sendData()
+message_handling_vel_ref      = make_float_handler("vel_ref")
+message_handling_P_gain       = make_float_handler("P_gain", 0.0, 5.0)
+message_handling_I_action     = make_float_handler("I_action", 0.0, 15.0)
+message_handling_feed_forward = make_float_handler("feed_forward")
 
 USB_connection_started = False # flag to check USB connection has been made
 USB_max_connect_attemps = 20

--- a/RPi/bash_scripts/start_spit.sh
+++ b/RPi/bash_scripts/start_spit.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# sleep 10
-# node-red-restart
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
 sleep 5
-python3 /home/pi/Documents/Spit-electronics/RPi/Spit_RPi_Arduino.py
+python3 "$SCRIPT_DIR/../Spit_RPi_Arduino.py"

--- a/RPi/install.sh
+++ b/RPi/install.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Set up Spit-electronics on a Raspberry Pi.
+# Assumes Node-Red is already installed (run nodered.org installer first if not).
+# Safe to re-run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FLOWS_PATH="$REPO_ROOT/RPi/node-red/flows.json"
+CREDS_PATH="$REPO_ROOT/RPi/node-red/flows_cred.json"
+START_SCRIPT="$REPO_ROOT/RPi/bash_scripts/start_spit.sh"
+SETTINGS="$HOME/.node-red/settings.js"
+
+if [ "$EUID" -eq 0 ]; then
+  echo "!! Don't run this as root. Run as the 'pi' user; the script will sudo where needed."
+  exit 1
+fi
+
+echo "==> Spit install from $REPO_ROOT"
+
+echo "==> apt update & upgrade"
+sudo apt update
+sudo apt upgrade -y
+
+echo "==> Installing Mosquitto"
+sudo apt install -y mosquitto mosquitto-clients
+sudo systemctl enable --now mosquitto.service
+
+echo "==> Installing Python + pip"
+sudo apt install -y python3 python3-pip
+
+echo "==> Installing Python packages"
+PIP_FLAGS=""
+# Bookworm+ marks the system Python as externally managed (PEP 668); pip needs
+# --break-system-packages to install into it. Older Pi OS doesn't recognise the flag.
+if compgen -G "/usr/lib/python3*/EXTERNALLY-MANAGED" >/dev/null; then
+  PIP_FLAGS="--break-system-packages"
+fi
+pip3 install $PIP_FLAGS paho-mqtt pySerialTransfer numpy
+
+echo "==> Checking for Node-Red"
+if ! command -v node-red >/dev/null; then
+  echo "!! Node-Red not found. Install it via:"
+  echo "   bash <(curl -sL https://raw.githubusercontent.com/node-red/linux-installers/master/deb/update-nodejs-and-nodered)"
+  echo "   then re-run this script."
+  exit 1
+fi
+sudo systemctl enable nodered.service
+
+if [ ! -f "$SETTINGS" ]; then
+  echo "==> Bootstrapping Node-Red to create settings.js"
+  sudo systemctl restart nodered.service
+  for _ in $(seq 1 30); do
+    [ -f "$SETTINGS" ] && break
+    sleep 1
+  done
+  if [ ! -f "$SETTINGS" ]; then
+    echo "!! settings.js was not created after 30s. Inspect 'journalctl -u nodered' and re-run."
+    exit 1
+  fi
+fi
+
+echo "==> Pointing Node-Red at repo flows"
+if grep -qE "^[[:space:]]*flowFile:[[:space:]]*'$FLOWS_PATH'" "$SETTINGS"; then
+  echo "   already set."
+else
+  cp "$SETTINGS" "$SETTINGS.bak.$(date +%s)"
+  if grep -qE '^[[:space:]]*(//[[:space:]]*)?flowFile:' "$SETTINGS"; then
+    sed -i -E "s|^[[:space:]]*(//[[:space:]]*)?flowFile:.*|    flowFile: '$FLOWS_PATH',|" "$SETTINGS"
+  else
+    sed -i "/module.exports = {/a\\    flowFile: '$FLOWS_PATH'," "$SETTINGS"
+  fi
+  if grep -qE '^[[:space:]]*(//[[:space:]]*)?credentialsFile:' "$SETTINGS"; then
+    sed -i -E "s|^[[:space:]]*(//[[:space:]]*)?credentialsFile:.*|    credentialsFile: '$CREDS_PATH',|" "$SETTINGS"
+  else
+    sed -i "/module.exports = {/a\\    credentialsFile: '$CREDS_PATH'," "$SETTINGS"
+  fi
+fi
+
+echo "==> Restarting Node-Red"
+sudo systemctl restart nodered.service
+
+chmod +x "$START_SCRIPT"
+
+echo "==> Crontab entry for $START_SCRIPT"
+if crontab -l 2>/dev/null | grep -qF "$START_SCRIPT"; then
+  echo "   already in crontab."
+else
+  (crontab -l 2>/dev/null; echo "@reboot sleep 10 $START_SCRIPT >> /home/pi/crontab_log.txt 2>&1") | crontab -
+fi
+
+echo
+echo "==> Done. Reboot the Pi to verify auto-start, then check:"
+echo "     sudo systemctl status nodered mosquitto"
+echo "     tail -f /home/pi/crontab_log.txt"

--- a/RPi/install.sh
+++ b/RPi/install.sh
@@ -2,8 +2,28 @@
 # Set up Spit-electronics on a Raspberry Pi.
 # Assumes Node-Red is already installed (run nodered.org installer first if not).
 # Safe to re-run.
+#
+# Usage:
+#   ./RPi/install.sh              # configure Spit; apt update only (no upgrade)
+#   ./RPi/install.sh --upgrade    # also run `apt upgrade -y` (system-wide)
 
 set -euo pipefail
+
+RUN_UPGRADE=0
+for arg in "$@"; do
+  case "$arg" in
+    --upgrade) RUN_UPGRADE=1 ;;
+    -h|--help)
+      sed -n '2,9p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "!! Unknown argument: $arg"
+      sed -n '2,9p' "$0"
+      exit 1
+      ;;
+  esac
+done
 
 SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -19,9 +39,14 @@ fi
 
 echo "==> Spit install from $REPO_ROOT"
 
-echo "==> apt update & upgrade"
+echo "==> apt update"
 sudo apt update
-sudo apt upgrade -y
+if [ "$RUN_UPGRADE" -eq 1 ]; then
+  echo "==> apt upgrade (system-wide, slow)"
+  sudo apt upgrade -y
+else
+  echo "    (skipping apt upgrade; pass --upgrade to run it)"
+fi
 
 echo "==> Installing Mosquitto"
 sudo apt install -y mosquitto mosquitto-clients

--- a/RPi/node-red/flows.json
+++ b/RPi/node-red/flows.json
@@ -302,8 +302,8 @@
         "outputs": 1,
         "useDifferentColor": false,
         "className": "",
-        "x": 710,
-        "y": 340,
+        "x": 730,
+        "y": 360,
         "wires": [
             []
         ]
@@ -747,6 +747,27 @@
         "wires": [
             [
                 "70c755b8ca6c5b9c"
+            ]
+        ]
+    },
+    {
+        "id": "f8b0ae32c4c2d933",
+        "type": "mqtt in",
+        "z": "f9e17605cf3ed006",
+        "name": "vel_ref_sent",
+        "topic": "mqtt/rpi/vel_ref_sent",
+        "qos": "2",
+        "datatype": "auto-detect",
+        "broker": "777307716499796d",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 690,
+        "y": 100,
+        "wires": [
+            [
+                "d0b5f14c0b33f71c"
             ]
         ]
     }

--- a/RPi/node-red/flows.json
+++ b/RPi/node-red/flows.json
@@ -1,13 +1,5 @@
 [
     {
-        "id": "fd540bce26c1c011",
-        "type": "tab",
-        "label": "Flow 1",
-        "disabled": true,
-        "info": "",
-        "env": []
-    },
-    {
         "id": "f9e17605cf3ed006",
         "type": "tab",
         "label": "Flow 3",
@@ -157,7 +149,7 @@
     {
         "id": "724857c6c1bff6f9",
         "type": "ui_tab",
-        "name": "Live view",
+        "name": "Spit Dash",
         "icon": "dashboard",
         "disabled": false,
         "hidden": false
@@ -172,46 +164,6 @@
         "width": "10",
         "collapse": true,
         "className": ""
-    },
-    {
-        "id": "1aa2ee68bc227041",
-        "type": "ui_spacer",
-        "z": "fd540bce26c1c011",
-        "name": "spacer",
-        "group": "380840898e423db0",
-        "order": 1,
-        "width": 1,
-        "height": 1
-    },
-    {
-        "id": "ce78c4151b3dca75",
-        "type": "ui_spacer",
-        "z": "fd540bce26c1c011",
-        "name": "spacer",
-        "group": "380840898e423db0",
-        "order": 1,
-        "width": 1,
-        "height": 1
-    },
-    {
-        "id": "9eb429f6899148c7",
-        "type": "ui_spacer",
-        "z": "fd540bce26c1c011",
-        "name": "spacer",
-        "group": "380840898e423db0",
-        "order": 1,
-        "width": 1,
-        "height": 1
-    },
-    {
-        "id": "7c1eedd9c36004dc",
-        "type": "ui_spacer",
-        "z": "fd540bce26c1c011",
-        "name": "spacer",
-        "group": "380840898e423db0",
-        "order": 1,
-        "width": 1,
-        "height": 1
     },
     {
         "id": "17188ca64a45c712",
@@ -233,145 +185,6 @@
         "className": ""
     },
     {
-        "id": "d29916a5a3b30dd6",
-        "type": "mqtt in",
-        "z": "fd540bce26c1c011",
-        "name": "vel_measured",
-        "topic": "mqtt/rpi/vel_measured",
-        "qos": "2",
-        "datatype": "auto-detect",
-        "broker": "777307716499796d",
-        "nl": false,
-        "rap": true,
-        "rh": 0,
-        "inputs": 0,
-        "x": 250,
-        "y": 220,
-        "wires": [
-            [
-                "31a78673b6b493de"
-            ]
-        ]
-    },
-    {
-        "id": "31a78673b6b493de",
-        "type": "ui_gauge",
-        "z": "fd540bce26c1c011",
-        "name": "",
-        "group": "a55b0b6cdaaca03d",
-        "order": 1,
-        "width": "0",
-        "height": "0",
-        "gtype": "gage",
-        "title": "Velocity",
-        "label": "%",
-        "format": "{{value | number:0}}",
-        "min": 0,
-        "max": "100",
-        "colors": [
-            "#00b500",
-            "#e6e600",
-            "#ca3838"
-        ],
-        "seg1": "",
-        "seg2": "",
-        "diff": false,
-        "className": "",
-        "x": 600,
-        "y": 220,
-        "wires": []
-    },
-    {
-        "id": "1ff372859358bc50",
-        "type": "ui_slider",
-        "z": "fd540bce26c1c011",
-        "name": "",
-        "label": "Velocity Setpoint",
-        "tooltip": "",
-        "group": "380840898e423db0",
-        "order": 1,
-        "width": "2",
-        "height": "8",
-        "passthru": false,
-        "outs": "all",
-        "topic": "topic",
-        "topicType": "msg",
-        "min": 0,
-        "max": "100",
-        "step": "1",
-        "className": "",
-        "x": 270,
-        "y": 340,
-        "wires": [
-            [
-                "e77faf990e1742cb",
-                "66677478bf9d76fa"
-            ]
-        ]
-    },
-    {
-        "id": "e77faf990e1742cb",
-        "type": "mqtt out",
-        "z": "fd540bce26c1c011",
-        "name": "",
-        "topic": "mqtt/rpi/vel_ref",
-        "qos": "2",
-        "retain": "false",
-        "respTopic": "",
-        "contentType": "",
-        "userProps": "",
-        "correl": "",
-        "expiry": "",
-        "broker": "777307716499796d",
-        "x": 640,
-        "y": 340,
-        "wires": []
-    },
-    {
-        "id": "66677478bf9d76fa",
-        "type": "ui_chart",
-        "z": "fd540bce26c1c011",
-        "name": "",
-        "group": "380840898e423db0",
-        "order": 5,
-        "width": "2",
-        "height": "8",
-        "label": "Velocity Setpoint",
-        "chartType": "bar",
-        "legend": "false",
-        "xformat": "HH:mm:ss",
-        "interpolate": "linear",
-        "nodata": "",
-        "dot": false,
-        "ymin": "0",
-        "ymax": "100",
-        "removeOlder": 1,
-        "removeOlderPoints": "",
-        "removeOlderUnit": "3600",
-        "cutout": 0,
-        "useOneColor": false,
-        "useUTC": false,
-        "colors": [
-            "#1f77b4",
-            "#aec7e8",
-            "#ff7f0e",
-            "#2ca02c",
-            "#98df8a",
-            "#d62728",
-            "#ff9896",
-            "#9467bd",
-            "#c5b0d5"
-        ],
-        "outputs": 1,
-        "useDifferentColor": false,
-        "className": "",
-        "x": 690,
-        "y": 420,
-        "wires": [
-            []
-        ]
-    },
-    {
         "id": "e622dd117aab7d73",
         "type": "mqtt in",
         "z": "f9e17605cf3ed006",
@@ -388,7 +201,9 @@
         "y": 140,
         "wires": [
             [
-                "6d0c7b0fd99379eb"
+                "6d0c7b0fd99379eb",
+                "fadcb10fca8e2f95",
+                "443b1854e9c7e81f"
             ]
         ]
     },
@@ -444,7 +259,8 @@
         "wires": [
             [
                 "fa53817379494857",
-                "8e9c71e22007baae"
+                "8e9c71e22007baae",
+                "f3fccb56fc147482"
             ]
         ]
     },
@@ -555,82 +371,10 @@
         "animate": true,
         "className": "",
         "x": 280,
-        "y": 440,
+        "y": 420,
         "wires": [
             [
                 "a7b1b3ae2177a9e7"
-            ]
-        ]
-    },
-    {
-        "id": "b613973bf18cf642",
-        "type": "ui_chart",
-        "z": "f9e17605cf3ed006",
-        "name": "",
-        "group": "2ca4d5acb5ecceec",
-        "order": 0,
-        "width": 0,
-        "height": 0,
-        "label": "chart",
-        "chartType": "line",
-        "legend": "false",
-        "xformat": "HH:mm:ss",
-        "interpolate": "linear",
-        "nodata": "",
-        "dot": false,
-        "ymin": "",
-        "ymax": "",
-        "removeOlder": 1,
-        "removeOlderPoints": "",
-        "removeOlderUnit": "3600",
-        "cutout": 0,
-        "useOneColor": false,
-        "useUTC": false,
-        "colors": [
-            "#1f77b4",
-            "#aec7e8",
-            "#ff7f0e",
-            "#2ca02c",
-            "#98df8a",
-            "#d62728",
-            "#ff9896",
-            "#9467bd",
-            "#c5b0d5"
-        ],
-        "outputs": 1,
-        "useDifferentColor": false,
-        "className": "",
-        "x": 630,
-        "y": 560,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "788f12256d76c636",
-        "type": "ui_button",
-        "z": "f9e17605cf3ed006",
-        "name": "",
-        "group": "2ca4d5acb5ecceec",
-        "order": 9,
-        "width": 0,
-        "height": 0,
-        "passthru": false,
-        "label": "button",
-        "tooltip": "",
-        "color": "",
-        "bgcolor": "",
-        "className": "",
-        "icon": "",
-        "payload": "1",
-        "payloadType": "str",
-        "topic": "topic",
-        "topicType": "msg",
-        "x": 310,
-        "y": 560,
-        "wires": [
-            [
-                "b613973bf18cf642"
             ]
         ]
     },
@@ -673,8 +417,8 @@
         "font": "Arial,Arial,Helvetica,sans-serif",
         "fontSize": "30",
         "color": "#0091ff",
-        "x": 640,
-        "y": 200,
+        "x": 920,
+        "y": 160,
         "wires": []
     },
     {
@@ -682,7 +426,7 @@
         "type": "function",
         "z": "f9e17605cf3ed006",
         "name": "function 1",
-        "func": "msgout= msg;\nmsgout.payload = msg.payload/3;\nreturn msgout;",
+        "func": "msgout= msg;\nmsgout.payload = msg.payload/ (3 * 4.667);\nreturn msgout;",
         "outputs": 1,
         "timeout": 0,
         "noerr": 0,
@@ -706,7 +450,7 @@
         "width": "0",
         "height": "0",
         "name": "",
-        "label": "# Rondjes varreke",
+        "label": "# Rondjes vlees",
         "format": "{{msg.payload | number:0}}",
         "layout": "row-right",
         "className": "",
@@ -714,57 +458,296 @@
         "font": "Arial,Arial,Helvetica,sans-serif",
         "fontSize": "30",
         "color": "#0091ff",
-        "x": 822.544921875,
-        "y": 193.34683227539062,
+        "x": 880,
+        "y": 220,
         "wires": []
     },
     {
-        "id": "b4ce10332c108beb",
-        "type": "ui_button",
+        "id": "fadcb10fca8e2f95",
+        "type": "function",
         "z": "f9e17605cf3ed006",
-        "name": "",
-        "group": "2ca4d5acb5ecceec",
-        "order": 9,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "label": "HANDELING BAS",
-        "tooltip": "",
-        "color": "",
-        "bgcolor": "",
-        "className": "",
-        "icon": "",
-        "payload": "1",
-        "payloadType": "num",
-        "topic": "topic",
-        "topicType": "msg",
-        "x": 330,
-        "y": 640,
+        "name": "function 2",
+        "func": "msg.payload = parseFloat(msg.payload);\nif (isNaN(msg.payload)) {\n    return null;  // Filter out bad data\n}\n\nmsg.topic = \"vel_measured\";\n// msg.timestamp = new Date().getTime();\n//msg.payload = [];\nreturn msg;\n",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 500,
+        "y": 20,
         "wires": [
             [
-                "f499cf9d76ec2968"
+                "d0b5f14c0b33f71c"
             ]
         ]
     },
     {
-        "id": "f499cf9d76ec2968",
-        "type": "ui_text",
+        "id": "d0b5f14c0b33f71c",
+        "type": "ui_chart",
         "z": "f9e17605cf3ed006",
-        "group": "2ca4d5acb5ecceec",
-        "order": 2,
+        "name": "",
+        "group": "a55b0b6cdaaca03d",
+        "order": 3,
         "width": 0,
         "height": 0,
-        "name": "",
-        "label": "text",
-        "format": "{{msg.payload}}",
-        "layout": "row-spread",
+        "label": "chart",
+        "chartType": "line",
+        "legend": "true",
+        "xformat": "HH:mm:ss",
+        "interpolate": "linear",
+        "nodata": "",
+        "dot": false,
+        "ymin": "0",
+        "ymax": "100",
+        "removeOlder": "10",
+        "removeOlderPoints": "100",
+        "removeOlderUnit": "1",
+        "cutout": 0,
+        "useOneColor": false,
+        "useUTC": false,
+        "colors": [
+            "#1f77b4",
+            "#aec7e8",
+            "#ff7f0e",
+            "#2ca02c",
+            "#98df8a",
+            "#d62728",
+            "#ff9896",
+            "#9467bd",
+            "#c5b0d5"
+        ],
+        "outputs": 1,
+        "useDifferentColor": false,
         "className": "",
-        "style": false,
-        "font": "",
-        "fontSize": 16,
-        "color": "#000000",
-        "x": 570,
-        "y": 640,
+        "x": 750,
+        "y": 40,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "f3fccb56fc147482",
+        "type": "function",
+        "z": "f9e17605cf3ed006",
+        "name": "function 4",
+        "func": "let setpoint = parseFloat(msg.payload);\nflow.set(\"latest_setpoint\", setpoint);",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 460,
+        "y": 360,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "443b1854e9c7e81f",
+        "type": "function",
+        "z": "f9e17605cf3ed006",
+        "name": "function 5",
+        "func": "let setpoint = flow.get(\"latest_setpoint\");\nif (setpoint !== undefined) {\n    return {\n        payload: setpoint,\n        topic: \"velocity_reference\"\n    };\n}\nreturn null;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 500,
+        "y": 80,
+        "wires": [
+            [
+                "d0b5f14c0b33f71c"
+            ]
+        ]
+    },
+    {
+        "id": "d050b49e9766aae2",
+        "type": "inject",
+        "z": "f9e17605cf3ed006",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": 0.1,
+        "topic": "velocity_reference",
+        "payload": "null",
+        "payloadType": "json",
+        "x": 340,
+        "y": 500,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "9e5056d465443458",
+        "type": "inject",
+        "z": "f9e17605cf3ed006",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": 0.1,
+        "topic": "vel_measured",
+        "payload": "null",
+        "payloadType": "json",
+        "x": 330,
+        "y": 560,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "9d5e33cc32f33a6c",
+        "type": "mqtt out",
+        "z": "f9e17605cf3ed006",
+        "name": "",
+        "topic": "mqtt/rpi/rx/p_gain",
+        "qos": "2",
+        "retain": "false",
+        "respTopic": "",
+        "contentType": "",
+        "userProps": "",
+        "correl": "",
+        "expiry": "",
+        "broker": "777307716499796d",
+        "x": 1250,
+        "y": 360,
         "wires": []
+    },
+    {
+        "id": "99019a99cef7bddf",
+        "type": "mqtt out",
+        "z": "f9e17605cf3ed006",
+        "name": "",
+        "topic": "mqtt/rpi/rx/i_action",
+        "qos": "2",
+        "retain": "false",
+        "respTopic": "",
+        "contentType": "",
+        "userProps": "",
+        "correl": "",
+        "expiry": "",
+        "broker": "777307716499796d",
+        "x": 1250,
+        "y": 420,
+        "wires": []
+    },
+    {
+        "id": "70c755b8ca6c5b9c",
+        "type": "mqtt out",
+        "z": "f9e17605cf3ed006",
+        "name": "",
+        "topic": "mqtt/rpi/rx/feed_forward",
+        "qos": "2",
+        "retain": "false",
+        "respTopic": "",
+        "contentType": "",
+        "userProps": "",
+        "correl": "",
+        "expiry": "",
+        "broker": "777307716499796d",
+        "x": 1310,
+        "y": 480,
+        "wires": []
+    },
+    {
+        "id": "07e1edaee20b80e6",
+        "type": "ui_text_input",
+        "z": "f9e17605cf3ed006",
+        "name": "",
+        "label": "P gain",
+        "tooltip": "",
+        "group": "380840898e423db0",
+        "order": 6,
+        "width": 0,
+        "height": 0,
+        "passthru": true,
+        "mode": "number",
+        "delay": 300,
+        "topic": "topic",
+        "sendOnBlur": true,
+        "className": "",
+        "topicType": "msg",
+        "x": 1050,
+        "y": 360,
+        "wires": [
+            [
+                "9d5e33cc32f33a6c"
+            ]
+        ]
+    },
+    {
+        "id": "2686b034b4e80f76",
+        "type": "ui_text_input",
+        "z": "f9e17605cf3ed006",
+        "name": "",
+        "label": "I gain",
+        "tooltip": "",
+        "group": "380840898e423db0",
+        "order": 6,
+        "width": 0,
+        "height": 0,
+        "passthru": true,
+        "mode": "number",
+        "delay": 300,
+        "topic": "topic",
+        "sendOnBlur": true,
+        "className": "",
+        "topicType": "msg",
+        "x": 1050,
+        "y": 420,
+        "wires": [
+            [
+                "99019a99cef7bddf"
+            ]
+        ]
+    },
+    {
+        "id": "76382f0e3f9f9c5c",
+        "type": "ui_text_input",
+        "z": "f9e17605cf3ed006",
+        "name": "",
+        "label": "Feed Forward",
+        "tooltip": "",
+        "group": "380840898e423db0",
+        "order": 6,
+        "width": 0,
+        "height": 0,
+        "passthru": true,
+        "mode": "number",
+        "delay": 300,
+        "topic": "topic",
+        "sendOnBlur": true,
+        "className": "",
+        "topicType": "msg",
+        "x": 1080,
+        "y": 480,
+        "wires": [
+            [
+                "70c755b8ca6c5b9c"
+            ]
+        ]
     }
 ]


### PR DESCRIPTION
## Summary
Cleanup pass on the Pi-side glue, plus a few real bug fixes uncovered along
the way. Five logically-distinct commits, kept separate for review.

- **Ramp on large mid-run setpoint changes** (`8512759`). The start-edge ramp
  already existed; this extends it so that slider moves while the motor is
  running also ramp from the current `vel_ref` to the new target instead of
  snapping. Mid-ramp slider moves just re-aim the in-flight ramp.

- **`RPi/install.sh`** (`cd81651`). One idempotent script that installs
  Mosquitto, Python deps (handles PEP 668 / `--break-system-packages`),
  configures Node-Red's `settings.js` to read flows from the repo, and adds
  the boot crontab entry. `start_spit.sh` is now path-relative so it works
  wherever the repo is cloned. Adds `.gitignore` (Node-Red atomic-write
  backups, `.claude/`) and `.gitattributes` (force LF on `*.sh` and `*.py`).

- **Stop busy-looping the Python main loop; gate `apt upgrade`**
  (`79f2277`). `Spit_RPi_Arduino.py` polled `link.available()` with no
  sleep, pegging a core at ~99%. Add `time.sleep(0.001)` for 1 kHz polling
  (still 20× the Arduino's 50 ms telemetry rate). Drops Python CPU to
  ~1–2% and clears up Node-Red sluggishness from core contention.
  `install.sh`'s `apt upgrade -y` is now opt-in via `--upgrade` so
  re-running after a `git pull` doesn't drag in a system upgrade by
  surprise.

- **Fix `~bool` idiom in USB-connect logic** (`c3841b7`).
  `~USB_connection_started` is `-2` (truthy), so the loop guard and the
  post-loop "could not connect" check didn't behave the way the names
  suggest. Could have exited the program after a successful reconnect if
  any prior attempt had failed. Switched both to `not …`. Same commit
  fixes two stale `Spit_RPi_Arduino_V3.py` references in the README.

README is updated to match: new "Quick start: `install.sh`" section, a
"Setpoint ramping" subsection in the protocol docs, SSH-not-SFTP warning
on `settings.js` editing (the silent-overwrite case that motivated the
script), and the two completed items dropped from the TODO list.

## Test plan
- [x] Ran `install.sh` on the Pi end-to-end; Mosquitto, Python deps, and
      Node-Red settings.js all configured idempotently.
- [x] After Python sleep fix, `top` shows `python3` at ~1–2% instead of
      99%. Node-Red Deploy feels snappier.
- [x] Node-Red Deploy in the browser writes through into the repo file
      (`git status` shows `flows.json` modified).
- [x] Mid-run slider moves now ramp instead of stepping.
- [ ] Reboot and verify auto-start crontab still launches the script
      with the new sleep in place.
- [ ] Verify the USB-connect path: pull `/dev/ttyACM0` out, restart the
      script, plug back in within attempt window — should connect cleanly
      and not exit after a transient failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)